### PR TITLE
FIX : 해당하는 영화 데이터가 없으면 태그 버튼 높이가 커지는 현상 수정

### DIFF
--- a/src/pages/Genre.js
+++ b/src/pages/Genre.js
@@ -10,16 +10,16 @@ export default function Genre() {
   const MainContainer = tw.div`
     w-[calc(100%-14rem)]
     ml-auto
-    flex
-    flex-wrap
+    flex flex-col
   `;
   const SelectedTag = tw.div`
-    text-3xl
+    text-3xl text-white
+    font-extrabold 
     w-full
-    mx-8
-    mt-12
-    font-extrabold
-    text-white
+    px-8 mt-12
+  `;
+  const CardContainer = tw.div`
+    flex flex-wrap
   `;
 
   const [movieData, setMovieData] = useState(null);
@@ -49,10 +49,12 @@ export default function Genre() {
               return `, ${item.name}`;
             })}
       </SelectedTag>
-      {movieData &&
-        movieData.results.map(data => {
-          return <MovieCard movieData={data} key={movieData.id} />;
-        })}
+      <CardContainer>
+        {movieData &&
+          movieData.results.map(data => {
+            return <MovieCard movieData={data} key={movieData.id} />;
+          })}
+      </CardContainer>
     </MainContainer>
   );
 }

--- a/src/styles/tagStyle.js
+++ b/src/styles/tagStyle.js
@@ -1,7 +1,7 @@
 import tw from 'tailwind-styled-components';
 
 const Container = tw.div`
-w-[100%]
+w-[100%-4rem]
 flex
 flex-wrap
 bg-black
@@ -22,14 +22,9 @@ my-1.5
 text-xl
 border-2
 rounded-3xl
-${tag =>
-  tag.isSelected
-    ? tw`bg-mainColor text-white`
-    : tw`bg-black text-white hover:bg-gray-800`}
 `;
 const SelectedTag = tw(TagContainer)`
 bg-mainColor
-flex
 items-center
 `;
 export { Container, TagContainer, SelectedTag };


### PR DESCRIPTION
## 해당하는 영화 데이터가 없으면 태그 버튼 높이가 커지는 현상 수정
- 수정 전 장르를 선택했을 때 해당하는 영화 데이터가 없으면 버튼 높이가 화면을 꽉 채우는 현상이 있었습니다.

[수정 후]
![image](https://github.com/FE-Sprint-Study/Namu-Movie/assets/49116370/4a3d8dcc-96ba-4ac9-ab2f-8dd8cee0baae)
